### PR TITLE
Mitigate ms-python.python 2025.5.2025042501 impact

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,7 @@ isort==5.13.2
 coverage==7.5.1
 flake8==7.1.0
 
+# VSCode - Unit test
+packaging==25.0 # required since .vscode\extensions\ms-python.python-2025.5.2025042501-win32-x64\python_files\unittestadapter\execution.py is not selfcontained
+
 # Project


### PR DESCRIPTION
ms-python.python 2025.5.2025042501 unit test adapter has a dependency on python module "packaging". Needed to run the unit tests from Visual Studio Code testing panel.

Added dependency to requirements.txt